### PR TITLE
调整翻译器的的判断逻辑，默认应用语言改为从LanguageResource读取

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             <dependency>
                 <groupId>cn.cerc</groupId>
                 <artifactId>summer-core</artifactId>
-                <version>2.2.1</version>
+                <version>2.2.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>

--- a/summer-mvc/src/main/java/cn/cerc/mis/config/ApplicationConfig.java
+++ b/summer-mvc/src/main/java/cn/cerc/mis/config/ApplicationConfig.java
@@ -86,7 +86,7 @@ public class ApplicationConfig {
         dataIn.getHead().setField("password", password);
         dataIn.getHead().setField("clientId", machineCode);
         dataIn.getHead().setField("device", AppClient.pc);
-        dataIn.getHead().setField("languageId", Language.zh_CN);
+        dataIn.getHead().setField("languageId", Application.App_Language);
         dataIn.getHead().setField("access", AccessLevel.Access_Task);// 访问层级获取队列授权
         String json = dataIn.getJSON();
         log.info("request params {}", json);

--- a/summer-mvc/src/main/java/cn/cerc/mis/core/AppClient.java
+++ b/summer-mvc/src/main/java/cn/cerc/mis/core/AppClient.java
@@ -114,7 +114,7 @@ public class AppClient implements IClient, Serializable {
 
     @Override
     public String getLanguage() {
-        return languageId == null ? Language.zh_CN : languageId;
+        return languageId == null ? Application.App_Language: languageId;
     }
 
     public String getToken() {

--- a/summer-mvc/src/main/java/cn/cerc/mis/core/Application.java
+++ b/summer-mvc/src/main/java/cn/cerc/mis/core/Application.java
@@ -1,6 +1,7 @@
 package cn.cerc.mis.core;
 
 import cn.cerc.core.IHandle;
+import cn.cerc.core.LanguageResource;
 import cn.cerc.core.SupportHandle;
 import cn.cerc.db.core.IAppConfig;
 import cn.cerc.db.core.ServerConfig;
@@ -38,12 +39,16 @@ public class Application {
 
     // 默认界面语言版本
     // FIXME: 2019/12/7 此处应改为从函数，并从配置文件中读取默认的语言类型
-    public static final String App_Language = Language.zh_CN; // 可选：cn/en
+    public static final String App_Language = getAppLanguage(); // 可选：cn/en
 
     private static ApplicationContext context;
 
     public static ApplicationContext getContext() {
         return context;
+    }
+
+    private static String getAppLanguage() {
+        return LanguageResource.appLanguage;
     }
 
     public static void setContext(ApplicationContext applicationContext) {

--- a/summer-mvc/src/main/java/cn/cerc/mis/language/R.java
+++ b/summer-mvc/src/main/java/cn/cerc/mis/language/R.java
@@ -50,10 +50,9 @@ public class R {
 
     public static String asString(IHandle handle, String text) {
         String language = getLanguageId(handle);
-        if (Application.App_Language.equals(language)) {
+        if (Application.App_Language.equals(Language.zh_CN)) {
             return text;
         }
-
         if (text == null || "".equals(text.trim())) {
             log.error("text is empty");
             return "file error";
@@ -97,12 +96,13 @@ public class R {
         SqlQuery dsLang = new SqlQuery(handle);
         dsLang.add("select Key_,max(Value_) as Value_ from %s", systemTable.getLanguage());
         dsLang.add("where Key_='%s'", Utils.safeString(text));
+        dsLang.add("and (Lang_='%s')", language);
         // FIXME: 2019/12/7 此处应该取反了，未来得及翻译的语言应该直接显示中文
-        if (Language.en_US.equals(language)) {
-            dsLang.add("and (Lang_='%s')", language);
-        } else {
-            dsLang.add("and (Lang_='%s' or Lang_='en')", language);
-        }
+        // if (Language.en_US.equals(language)) {
+        //     dsLang.add("and (Lang_='%s')", language);
+        // } else {
+        //     dsLang.add("and (Lang_='%s' or Lang_='en')", language);
+        // }
         dsLang.add("group by Key_");
         dsLang.open();
         String result = dsLang.getString("Value_");

--- a/summer-ui/src/main/java/cn/cerc/ui/fields/AbstractField.java
+++ b/summer-ui/src/main/java/cn/cerc/ui/fields/AbstractField.java
@@ -13,9 +13,7 @@ import cn.cerc.ui.parts.UIComponent;
 import cn.cerc.ui.vcl.UIText;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 public abstract class AbstractField extends UIComponent implements IField {
     // 数据库相关
     protected String field;

--- a/summer-ui/src/main/java/cn/cerc/ui/other/OperaPages.java
+++ b/summer-ui/src/main/java/cn/cerc/ui/other/OperaPages.java
@@ -1,5 +1,7 @@
 package cn.cerc.ui.other;
 
+import javax.servlet.http.HttpServletRequest;
+
 import cn.cerc.core.ClassResource;
 import cn.cerc.core.IUserLanguage;
 import cn.cerc.mis.core.IForm;
@@ -8,11 +10,7 @@ import cn.cerc.ui.core.HtmlWriter;
 import cn.cerc.ui.grid.MutiPage;
 import cn.cerc.ui.parts.UIComponent;
 import cn.cerc.ui.parts.UISheet;
-import lombok.extern.slf4j.Slf4j;
 
-import javax.servlet.http.HttpServletRequest;
-
-@Slf4j
 public class OperaPages extends UISheet implements IUserLanguage {
     private final ClassResource res = new ClassResource(this, "summer-ui");
 


### PR DESCRIPTION
link to summer-core [#6](https://github.com/cn-cerc/summer-core/pull/6)